### PR TITLE
Updated anchor for Internal redirects on Controller documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ http://symfony.com/doc/2.3/components/http_foundation/sessions.html#flash-messag
 * Redirects  
 http://symfony.com/doc/2.3/book/controller.html#redirecting
 * Internal redirects  
-http://symfony.com/doc/2.3/book/controller.html#forwarding
+http://symfony.com/doc/2.3/book/controller.html#forwarding-to-another-controller
 * Generate 404 pages  
 http://symfony.com/doc/2.3/book/controller.html#managing-errors-and-404-pages
 http://symfony.com/doc/2.3/cookbook/controller/error_pages.html#customizing-the-404-page-and-other-error-pages


### PR DESCRIPTION
Anchor for the forwarding part has been moved in this commit : https://github.com/symfony/symfony-docs/commit/6ef10db23d7e3fa747c201b8eaedb2a2da626545